### PR TITLE
Added Asynchronous Success function support

### DIFF
--- a/src/createDialog.js
+++ b/src/createDialog.js
@@ -6,6 +6,7 @@ angular.module('fundoo.services', []).factory('createDialog', ["$document", "$co
       templateUrl: null,
       title: 'Default Title',
       backdrop: true,
+      asyncSuccess: false,
       success: {label: 'OK', fn: null},
       cancel: {label: 'Close', fn: null},
       controller: null, //just like route controller declaration
@@ -109,8 +110,12 @@ angular.module('fundoo.services', []).factory('createDialog', ["$document", "$co
       };
       scope.$modalSuccess = function () {
         var callFn = options.success.fn || closeFn;
-        callFn.call(this);
-        scope.$modalClose();
+        if (options.asyncSuccess) {
+          callFn(this, scope.$modalClose);
+        } else {
+          callFn.call(this);
+          scope.$modalClose();
+        }
       };
       scope.$modalSuccessLabel = options.success.label;
       scope.$modalCancelLabel = options.cancel.label;


### PR DESCRIPTION
If asyncSuccess is true then the success function will be called with the controller(this) as the first parameter and the close dialog function as the second parameter.

This allows you to conditionally continue. In my case I needed the success to not close the dialog if perhaps the data entered in the dialog was invalid. Also I needed to validate asynchronously.

FYI if this is not something fundoo-solutions doesn't want in createDialog thats fine. I just needed it for my project. :-)
