### PR TITLE
added support to display scope var in templates

### DIFF
--- a/src/createDialog.js
+++ b/src/createDialog.js
@@ -120,6 +120,7 @@ angular.module('fundoo.services', []).factory('createDialog', ["$document", "$co
         ctrl = $controller(options.controller, locals);
         // Yes, ngControllerController is not a typo
         modalEl.contents().data('$ngControllerController', ctrl);
+        scope = angular.extend(scope, locals.$scope);
       }
 
       $compile(modalEl)(scope);


### PR DESCRIPTION
This fix allows {modal_custom_data} scope to be used in template.
